### PR TITLE
Add scoped About page hero and CTA styling

### DIFF
--- a/assets/about.css
+++ b/assets/about.css
@@ -1,0 +1,129 @@
+/* About page scoped styles */
+.about-hero,
+.about-cta {
+  --about-gap: clamp(1.5rem, 2vw + 1rem, 4rem);
+  --about-text-max: 60ch;
+  --about-heading-size: clamp(2.25rem, 1.6rem + 2vw, 3.75rem);
+  --about-subheading-size: clamp(1.125rem, 1rem + 0.8vw, 1.5rem);
+  --about-body-size: clamp(1rem, 0.95rem + 0.3vw, 1.125rem);
+  --about-button-gap: clamp(1rem, 0.75rem + 0.8vw, 1.75rem);
+  --about-section-radius: 1.25rem;
+}
+
+.about-hero,
+.about-cta {
+  padding-block: calc(var(--about-gap) * 1.25);
+  padding-inline: var(--about-gap);
+}
+
+.about-hero__inner,
+.about-cta__inner {
+  display: grid;
+  gap: var(--about-gap);
+  max-width: min(64rem, 100%);
+  margin-inline: auto;
+}
+
+.about-hero__inner {
+  align-items: center;
+}
+
+.about-hero__content {
+  display: grid;
+  gap: var(--about-button-gap);
+  max-width: var(--about-text-max);
+}
+
+.about-hero__eyebrow {
+  font-size: var(--about-body-size);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(var(--color-foreground), 0.7);
+}
+
+.about-hero__heading {
+  font-size: var(--about-heading-size);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+}
+
+.about-hero__text,
+.about-cta__text {
+  font-size: var(--about-body-size);
+  line-height: 1.7;
+  color: rgba(var(--color-foreground), 0.8);
+}
+
+.about-hero__media {
+  border-radius: var(--about-section-radius);
+  overflow: hidden;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.08);
+}
+
+.about-hero__media img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.about-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.about-cta {
+  background: rgba(var(--color-background-contrast), 0.05);
+  border-radius: var(--about-section-radius);
+}
+
+.about-cta__inner {
+  justify-items: center;
+  text-align: center;
+}
+
+.about-cta__heading {
+  font-size: clamp(1.75rem, 1.4rem + 1.2vw, 2.5rem);
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+}
+
+.about-cta__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.about-cta__content {
+  max-width: calc(var(--about-text-max) - 8ch);
+  display: grid;
+  gap: var(--about-button-gap);
+}
+
+@media (min-width: 48rem) {
+  .about-hero__inner {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .about-hero--image-left .about-hero__inner {
+    direction: rtl;
+  }
+
+  .about-hero--image-left .about-hero__content,
+  .about-hero--image-left .about-hero__media {
+    direction: ltr;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .about-hero__media img,
+  .about-hero__heading {
+    transition: transform 300ms ease, box-shadow 300ms ease;
+  }
+
+  .about-hero__media:hover img {
+    transform: scale(1.02);
+  }
+}

--- a/sections/about-cta.liquid
+++ b/sections/about-cta.liquid
@@ -1,0 +1,132 @@
+{{ 'about.css' | asset_url | stylesheet_tag }}
+
+<section class="section about-cta color-{{ section.settings.color_scheme }} gradient">
+  <div class="about-cta__inner page-width">
+    <div class="about-cta__content">
+      {%- assign heading_tag = section.settings.heading_tag -%}
+      {%- if section.settings.heading != blank -%}
+        <{{ heading_tag }} class="about-cta__heading">{{ section.settings.heading | escape }}</{{ heading_tag }}>
+      {%- endif -%}
+
+      {%- if section.settings.text != blank -%}
+        <div class="about-cta__text rte">
+          {{ section.settings.text }}
+        </div>
+      {%- endif -%}
+
+      {%- if section.settings.button_label != blank or section.settings.secondary_button_label != blank -%}
+        <div class="about-cta__actions">
+          {%- if section.settings.button_label != blank -%}
+            <a
+              {% if section.settings.button_link == blank %}
+                role="link"
+                aria-disabled="true"
+              {% else %}
+                href="{{ section.settings.button_link }}"
+              {% endif %}
+              class="button{% if section.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}"
+            >
+              {{- section.settings.button_label | escape -}}
+            </a>
+          {%- endif -%}
+          {%- if section.settings.secondary_button_label != blank -%}
+            <a
+              {% if section.settings.secondary_button_link == blank %}
+                role="link"
+                aria-disabled="true"
+              {% else %}
+                href="{{ section.settings.secondary_button_link }}"
+              {% endif %}
+              class="button{% if section.settings.secondary_button_style_secondary %} button--secondary{% else %} button--primary{% endif %}"
+            >
+              {{- section.settings.secondary_button_label | escape -}}
+            </a>
+          {%- endif -%}
+        </div>
+      {%- endif -%}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "About call-to-action",
+  "tag": "section",
+  "class": "section about",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Ready to join the journey?"
+    },
+    {
+      "type": "select",
+      "id": "heading_tag",
+      "label": "Heading level",
+      "options": [
+        { "value": "h2", "label": "H2" },
+        { "value": "h3", "label": "H3" },
+        { "value": "h4", "label": "H4" }
+      ],
+      "default": "h2"
+    },
+    {
+      "type": "richtext",
+      "id": "text",
+      "label": "Text",
+      "default": "<p>Invite your community to explore your products, read your story, or connect with your team.</p>"
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "label": "Primary button label",
+      "default": "Explore products"
+    },
+    {
+      "type": "url",
+      "id": "button_link",
+      "label": "Primary button link"
+    },
+    {
+      "type": "checkbox",
+      "id": "button_style_secondary",
+      "label": "Use secondary style for primary button",
+      "default": false
+    },
+    {
+      "type": "text",
+      "id": "secondary_button_label",
+      "label": "Secondary button label"
+    },
+    {
+      "type": "url",
+      "id": "secondary_button_link",
+      "label": "Secondary button link"
+    },
+    {
+      "type": "checkbox",
+      "id": "secondary_button_style_secondary",
+      "label": "Use secondary style for secondary button",
+      "default": true
+    },
+    {
+      "type": "select",
+      "id": "color_scheme",
+      "label": "Color scheme",
+      "default": "scheme-1",
+      "options": [
+        { "value": "scheme-1", "label": "t:sections.all.colors.scheme_1" },
+        { "value": "scheme-2", "label": "t:sections.all.colors.scheme_2" },
+        { "value": "scheme-3", "label": "t:sections.all.colors.scheme_3" },
+        { "value": "scheme-4", "label": "t:sections.all.colors.scheme_4" }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "About call-to-action"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/about-hero.liquid
+++ b/sections/about-hero.liquid
@@ -1,0 +1,151 @@
+{{ 'about.css' | asset_url | stylesheet_tag }}
+
+{%- liquid
+  assign fetch_priority = 'auto'
+  if section.index == 1
+    assign fetch_priority = 'high'
+  endif
+  assign image_position = section.settings.image_position
+  if section.settings.image == blank
+    assign image_position = 'right'
+  endif
+-%}
+
+<section class="section about-hero about-hero--image-{{ image_position }} color-{{ section.settings.color_scheme }} gradient">
+  <div class="about-hero__inner page-width">
+    {%- if section.settings.image != blank -%}
+      <div class="about-hero__media">
+        {{
+          section.settings.image
+          | image_url: width: 1600
+          | image_tag:
+            loading: 'lazy',
+            fetchpriority: fetch_priority,
+            sizes: '(min-width: 960px) 44vw, 100vw'
+        }}
+      </div>
+    {%- endif -%}
+
+    <div class="about-hero__content">
+      {%- if section.settings.kicker != blank -%}
+        <p class="about-hero__eyebrow">{{ section.settings.kicker | escape }}</p>
+      {%- endif -%}
+
+      {%- assign heading_tag = section.settings.heading_tag -%}
+      {%- if section.settings.heading != blank -%}
+        <{{ heading_tag }} class="about-hero__heading">
+          {{ section.settings.heading | escape }}
+        </{{ heading_tag }}>
+      {%- endif -%}
+
+      {%- if section.settings.text != blank -%}
+        <div class="about-hero__text rte">
+          {{ section.settings.text }}
+        </div>
+      {%- endif -%}
+
+      {%- if section.settings.button_label != blank -%}
+        <div class="about-hero__actions">
+          <a
+            {% if section.settings.button_link == blank %}
+              role="link"
+              aria-disabled="true"
+            {% else %}
+              href="{{ section.settings.button_link }}"
+            {% endif %}
+            class="button{% if section.settings.button_style_secondary %} button--secondary{% else %} button--primary{% endif %}"
+          >
+            {{- section.settings.button_label | escape -}}
+          </a>
+        </div>
+      {%- endif -%}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "About hero",
+  "tag": "section",
+  "class": "section about",
+  "settings": [
+    {
+      "type": "text",
+      "id": "kicker",
+      "label": "Eyebrow text"
+    },
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Our story"
+    },
+    {
+      "type": "select",
+      "id": "heading_tag",
+      "label": "Heading level",
+      "options": [
+        { "value": "h1", "label": "H1" },
+        { "value": "h2", "label": "H2" },
+        { "value": "h3", "label": "H3" }
+      ],
+      "default": "h1"
+    },
+    {
+      "type": "richtext",
+      "id": "text",
+      "label": "Text",
+      "default": "<p>Share a short introduction to your brand. Highlight what makes you unique and what customers can expect.</p>"
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "label": "Button label",
+      "default": "Shop the collection"
+    },
+    {
+      "type": "url",
+      "id": "button_link",
+      "label": "Button link"
+    },
+    {
+      "type": "checkbox",
+      "id": "button_style_secondary",
+      "label": "Use secondary button style",
+      "default": false
+    },
+    {
+      "type": "image_picker",
+      "id": "image",
+      "label": "Image"
+    },
+    {
+      "type": "select",
+      "id": "image_position",
+      "label": "Image position",
+      "options": [
+        { "value": "right", "label": "Image right" },
+        { "value": "left", "label": "Image left" }
+      ],
+      "default": "right"
+    },
+    {
+      "type": "select",
+      "id": "color_scheme",
+      "label": "Color scheme",
+      "default": "scheme-1",
+      "options": [
+        { "value": "scheme-1", "label": "t:sections.all.colors.scheme_1" },
+        { "value": "scheme-2", "label": "t:sections.all.colors.scheme_2" },
+        { "value": "scheme-3", "label": "t:sections.all.colors.scheme_3" },
+        { "value": "scheme-4", "label": "t:sections.all.colors.scheme_4" }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "About hero"
+    }
+  ]
+}
+{% endschema %}

--- a/templates/page.about.json
+++ b/templates/page.about.json
@@ -1,0 +1,37 @@
+{
+  "sections": {
+    "hero": {
+      "type": "about-hero",
+      "settings": {
+        "kicker": "About us",
+        "heading": "Purposefully crafted essentials",
+        "heading_tag": "h1",
+        "text": "<p>We believe in thoughtful details, long-lasting materials, and sharing the journey openly. Get to know the team behind every product.</p>",
+        "button_label": "Shop now",
+        "button_link": "shopify://collections/all",
+        "button_style_secondary": false,
+        "image_position": "right",
+        "color_scheme": "scheme-1"
+      }
+    },
+    "cta": {
+      "type": "about-cta",
+      "settings": {
+        "heading": "Let&apos;s stay in touch",
+        "heading_tag": "h2",
+        "text": "<p>Join our newsletter for behind-the-scenes updates, product drops, and stories from the workshop.</p>",
+        "button_label": "Subscribe",
+        "button_link": "shopify://pages/contact",
+        "button_style_secondary": false,
+        "secondary_button_label": "Read our journal",
+        "secondary_button_link": "shopify://blogs/news",
+        "secondary_button_style_secondary": true,
+        "color_scheme": "scheme-1"
+      }
+    }
+  },
+  "order": [
+    "hero",
+    "cta"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a dedicated about.css token set to control spacing and typography for About-only sections
- build About hero and CTA sections that consume the scoped styles and expose content settings
- register an About page template that composes the new hero and CTA blocks

## Testing
- npm run check *(fails: repo does not contain package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d82a54f72c8328b13c7d3db79a20c7