### PR TITLE
feat: add sticky sticky slides for about page

### DIFF
--- a/assets/about-sticky.js
+++ b/assets/about-sticky.js
@@ -1,0 +1,294 @@
+class AboutStickySlides {
+  constructor(section) {
+    this.section = section;
+    this.sectionId = section.dataset.sectionId || section.id;
+    this.items = Array.from(section.querySelectorAll('[data-sticky-item]'));
+    this.visualContainer = section.querySelector('[data-sticky-visual]');
+    this.mediaTarget = section.querySelector('[data-sticky-visual-target]');
+    this.visualSurface = this.mediaTarget ? this.mediaTarget.parentElement : null;
+    this.activeItem = null;
+    this.activeMedia = null;
+
+    if (!this.items.length || !this.mediaTarget) {
+      return;
+    }
+
+    this.motionQuery = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+    this.prefersReducedMotion = !!(this.motionQuery && this.motionQuery.matches);
+    this.motionListener = () => {
+      this.prefersReducedMotion = !!(this.motionQuery && this.motionQuery.matches);
+      if (this.activeMedia instanceof HTMLVideoElement) {
+        this.updateVideoPlayback(this.activeMedia);
+      }
+    };
+
+    if (this.motionQuery) {
+      if (this.motionQuery.addEventListener) {
+        this.motionQuery.addEventListener('change', this.motionListener);
+      } else if (this.motionQuery.addListener) {
+        this.motionQuery.addListener(this.motionListener);
+      }
+    }
+
+    if (typeof window.IntersectionObserver !== 'function') {
+      this.activateItem(this.items[0]);
+      return;
+    }
+
+    this.handleIntersections = this.handleIntersections.bind(this);
+    this.observer = new IntersectionObserver(this.handleIntersections, {
+      threshold: 0.5,
+      rootMargin: '0px 0px -35% 0px',
+    });
+
+    this.items.forEach((item) => {
+      this.observer.observe(item);
+    });
+
+    // Activate the first item immediately so an initial visual is rendered.
+    this.activateItem(this.items[0]);
+  }
+
+  handleIntersections(entries) {
+    entries.forEach((entry) => {
+      const { target } = entry;
+      if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+        this.activateItem(target);
+        return;
+      }
+
+      if (!entry.isIntersecting && this.activeItem === target) {
+        this.pauseItemMedia(target);
+        target.classList.remove('is-active');
+        this.activeMedia = null;
+        this.activeItem = null;
+        return;
+      }
+
+      if (!entry.isIntersecting) {
+        target.classList.remove('is-active');
+      }
+    });
+  }
+
+  activateItem(item) {
+    if (!item || this.activeItem === item) {
+      return;
+    }
+
+    if (this.activeItem && this.activeItem !== item) {
+      this.pauseItemMedia(this.activeItem);
+      this.activeItem.classList.remove('is-active');
+    }
+
+    this.activeItem = item;
+    this.activeItem.classList.add('is-active');
+    this.swapVisualForItem(item);
+  }
+
+  swapVisualForItem(item) {
+    if (!this.mediaTarget) return;
+
+    if (this.activeMedia) {
+      if (this.activeMedia instanceof HTMLVideoElement) {
+        this.activeMedia.pause();
+      }
+      if (this.activeMedia.parentElement === this.mediaTarget) {
+        this.mediaTarget.removeChild(this.activeMedia);
+      }
+      this.activeMedia = null;
+    }
+
+    this.mediaTarget.innerHTML = '';
+
+    const background = item.dataset.bg;
+    const visualSurface = this.visualSurface || this.visualContainer;
+    if (visualSurface) {
+      if (background) {
+        visualSurface.style.backgroundColor = background;
+      } else {
+        visualSurface.style.removeProperty('background-color');
+      }
+    }
+
+    const videoSrc = item.dataset.video;
+    if (videoSrc) {
+      const video = this.getOrCreateVideo(item, videoSrc);
+      if (video) {
+        this.mediaTarget.appendChild(video);
+        this.activeMedia = video;
+        this.updateVideoPlayback(video);
+      }
+      return;
+    }
+
+    const image = item.querySelector('[data-slide-image]');
+    if (image) {
+      const clone = image.cloneNode(true);
+      clone.hidden = false;
+      clone.removeAttribute('hidden');
+      clone.removeAttribute('data-slide-image');
+      clone.classList.remove('about-sticky-slides__preload-image');
+      clone.setAttribute('data-active-slide', '');
+      this.mediaTarget.appendChild(clone);
+      this.activeMedia = clone;
+    }
+  }
+
+  pauseItemMedia(item) {
+    if (!item) return;
+    const video = item._aboutStickyVideo;
+    if (video instanceof HTMLVideoElement) {
+      video.pause();
+      video.removeAttribute('autoplay');
+    }
+  }
+
+  getOrCreateVideo(item, src) {
+    if (!item._aboutStickyVideo) {
+      const video = document.createElement('video');
+      video.src = src;
+      video.setAttribute('playsinline', '');
+      video.setAttribute('muted', '');
+      video.setAttribute('loop', '');
+      video.muted = true;
+      video.loop = true;
+      video.playsInline = true;
+      video.preload = 'metadata';
+      video.className = 'about-sticky-slides__video';
+      video.tabIndex = -1;
+      video.setAttribute('aria-hidden', 'true');
+      item._aboutStickyVideo = video;
+    } else if (item._aboutStickyVideo.src !== src) {
+      item._aboutStickyVideo.src = src;
+      item._aboutStickyVideo.load();
+    }
+
+    return item._aboutStickyVideo;
+  }
+
+  updateVideoPlayback(video) {
+    if (!(video instanceof HTMLVideoElement)) return;
+
+    if (this.prefersReducedMotion) {
+      video.pause();
+      video.removeAttribute('autoplay');
+      video.currentTime = 0;
+      return;
+    }
+
+    video.setAttribute('autoplay', '');
+    const playPromise = video.play();
+    if (playPromise && typeof playPromise.then === 'function') {
+      playPromise.catch(() => {
+        // Ignore autoplay errors triggered by browser policies.
+      });
+    }
+  }
+
+  activateByBlockId(blockId, { scrollIntoView = false } = {}) {
+    if (!blockId) return;
+    const item = this.items.find((entry) => entry.dataset.blockId === blockId);
+    if (!item) return;
+
+    if (scrollIntoView) {
+      const prefersReducedMotion = this.prefersReducedMotion;
+      item.scrollIntoView({
+        behavior: prefersReducedMotion ? 'auto' : 'smooth',
+        block: 'center',
+      });
+    }
+
+    this.activateItem(item);
+  }
+
+  destroy() {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+
+    this.items.forEach((item) => {
+      this.pauseItemMedia(item);
+    });
+
+    if (this.mediaTarget) {
+      this.mediaTarget.innerHTML = '';
+    }
+
+    if (this.motionQuery) {
+      if (this.motionQuery.removeEventListener) {
+        this.motionQuery.removeEventListener('change', this.motionListener);
+      } else if (this.motionQuery.removeListener) {
+        this.motionQuery.removeListener(this.motionListener);
+      }
+    }
+  }
+}
+
+const aboutStickyInstances = new Map();
+
+const initAboutStickySections = (root = document) => {
+  const sections = root.querySelectorAll('[data-about-sticky]');
+  sections.forEach((section) => {
+    const id = section.dataset.sectionId || section.id;
+    if (!id || aboutStickyInstances.has(id)) {
+      return;
+    }
+    const instance = new AboutStickySlides(section);
+    if (instance && instance.items && instance.items.length) {
+      aboutStickyInstances.set(id, instance);
+    }
+  });
+};
+
+const unloadAboutStickySection = (sectionId) => {
+  const instance = aboutStickyInstances.get(sectionId);
+  if (!instance) return;
+  instance.destroy();
+  aboutStickyInstances.delete(sectionId);
+};
+
+const handleBlockSelect = (event) => {
+  const { sectionId, blockId } = event.detail || {};
+  if (!sectionId || !blockId) return;
+  const instance = aboutStickyInstances.get(sectionId);
+  if (!instance) return;
+  instance.activateByBlockId(blockId, { scrollIntoView: true });
+};
+
+const handleBlockDeselect = (event) => {
+  const { sectionId, blockId } = event.detail || {};
+  if (!sectionId || !blockId) return;
+  const instance = aboutStickyInstances.get(sectionId);
+  if (!instance) return;
+  instance.activateByBlockId(blockId);
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => initAboutStickySections());
+} else {
+  initAboutStickySections();
+}
+
+document.addEventListener('shopify:section:load', (event) => {
+  const section = event.target.querySelector('[data-about-sticky]');
+  const sectionId = event.detail && event.detail.sectionId;
+  if (!section) return;
+  initAboutStickySections(event.target);
+  if (sectionId) {
+    const instance = aboutStickyInstances.get(sectionId);
+    if (instance) {
+      instance.activateItem(instance.items[0]);
+    }
+  }
+});
+
+document.addEventListener('shopify:section:unload', (event) => {
+  const sectionId = event.detail && event.detail.sectionId;
+  if (!sectionId) return;
+  unloadAboutStickySection(sectionId);
+});
+
+document.addEventListener('shopify:block:select', handleBlockSelect);
+
+document.addEventListener('shopify:block:deselect', handleBlockDeselect);

--- a/assets/about.css
+++ b/assets/about.css
@@ -130,3 +130,147 @@
     order: 1;
   }
 }
+
+.template-page-about .about-sticky-slides {
+  padding-inline: clamp(1.6rem, 6vw, 5.6rem);
+  padding-block: var(--about-gap);
+}
+
+.template-page-about .about-sticky-slides__inner {
+  margin-inline: auto;
+  max-width: var(--about-content-max);
+  display: grid;
+  gap: clamp(2.4rem, 5vw, 4.8rem);
+}
+
+.template-page-about .about-sticky-slides__intro {
+  display: grid;
+  gap: clamp(1rem, 3vw, 1.8rem);
+  max-width: 60ch;
+}
+
+.template-page-about .about-sticky-slides__eyebrow {
+  font-size: var(--about-subheading-size);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(var(--color-foreground), 0.7);
+}
+
+.template-page-about .about-sticky-slides__heading {
+  font-size: clamp(2.8rem, 6vw, 4rem);
+  line-height: 1.12;
+  letter-spacing: -0.01em;
+}
+
+.template-page-about .about-sticky-slides__body {
+  font-size: var(--about-body-size);
+  color: rgba(var(--color-foreground), 0.78);
+}
+
+.template-page-about .about-sticky-slides__layout {
+  display: grid;
+  gap: clamp(2.4rem, 6vw, 5.6rem);
+}
+
+.template-page-about .about-sticky-slides__copy {
+  display: grid;
+  gap: clamp(1.6rem, 4vw, 2.4rem);
+}
+
+.template-page-about .about-sticky-slides__item {
+  padding: clamp(1.6rem, 4vw, 2.4rem);
+  border-radius: clamp(1rem, 3vw, 1.6rem);
+  background: rgba(var(--color-foreground), 0.04);
+  display: grid;
+  gap: clamp(0.8rem, 2.6vw, 1.2rem);
+  transition: transform 280ms ease, background-color 280ms ease, box-shadow 280ms ease;
+}
+
+.template-page-about .about-sticky-slides__item-eyebrow {
+  font-size: var(--about-subheading-size);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(var(--color-foreground), 0.64);
+}
+
+.template-page-about .about-sticky-slides__item-heading {
+  font-size: clamp(2.2rem, 5vw, 3rem);
+  line-height: 1.2;
+}
+
+.template-page-about .about-sticky-slides__item-body {
+  font-size: var(--about-body-size);
+  color: rgba(var(--color-foreground), 0.8);
+}
+
+.template-page-about .about-sticky-slides__item-link {
+  font-weight: 600;
+  color: rgb(var(--color-foreground));
+  text-decoration: underline;
+  text-decoration-thickness: 0.1em;
+}
+
+.template-page-about .about-sticky-slides__item.is-active {
+  background: rgba(var(--color-foreground), 0.08);
+  box-shadow: 0 1.2rem 2.8rem rgba(15, 23, 42, 0.12);
+  transform: translateY(-0.4rem);
+}
+
+.template-page-about .about-sticky-slides__visual {
+  position: relative;
+}
+
+.template-page-about .about-sticky-slides__visual-media {
+  aspect-ratio: 4 / 5;
+  width: 100%;
+  border-radius: min(1.6rem, var(--media-radius));
+  overflow: hidden;
+  background: rgba(var(--color-foreground), 0.06);
+  display: grid;
+  place-items: center;
+}
+
+.template-page-about .about-sticky-slides__visual-media > * {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.template-page-about .about-sticky-slides__video {
+  display: block;
+}
+
+.template-page-about .about-sticky-slides__preload-image {
+  display: none;
+}
+
+@media screen and (min-width: 768px) {
+  .template-page-about .about-sticky-slides__layout {
+    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .template-page-about .about-sticky-slides__visual {
+    position: sticky;
+    top: 80px;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .template-page-about .about-sticky-slides__layout {
+    gap: clamp(2rem, 8vw, 3.2rem);
+  }
+
+  .template-page-about .about-sticky-slides__visual {
+    position: relative;
+    top: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .template-page-about .about-sticky-slides__item {
+    transition: none;
+    transform: none !important;
+  }
+}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -368,6 +368,10 @@
       };
     </script>
 
+    {%- if template.name == 'page' and template.suffix == 'about' -%}
+      <script src="{{ 'about-sticky.js' | asset_url }}" defer="defer"></script>
+    {%- endif -%}
+
     {%- if settings.predictive_search_enabled -%}
       <script src="{{ 'predictive-search.js' | asset_url }}" defer="defer"></script>
     {%- endif -%}

--- a/sections/about-sticky-slides.liquid
+++ b/sections/about-sticky-slides.liquid
@@ -1,0 +1,174 @@
+{% liquid
+  assign intro_heading = section.settings.heading
+  assign intro_subheading = section.settings.subheading
+  assign intro_text = section.settings.body
+%}
+
+<section
+  class="about-sticky-slides section-{{ section.id }}"
+  data-about-sticky
+  data-section-id="{{ section.id }}"
+>
+  <div class="about-sticky-slides__inner">
+    {% if intro_heading or intro_subheading or intro_text != blank %}
+      <header class="about-sticky-slides__intro">
+        {% if intro_subheading %}
+          <p class="about-sticky-slides__eyebrow">{{ intro_subheading | escape }}</p>
+        {% endif %}
+        {% if intro_heading %}
+          <h2 class="about-sticky-slides__heading">{{ intro_heading | escape }}</h2>
+        {% endif %}
+        {% if intro_text %}
+          <div class="about-sticky-slides__body rte">{{ intro_text }}</div>
+        {% endif %}
+      </header>
+    {% endif %}
+
+    {% if section.blocks.size > 0 %}
+      <div class="about-sticky-slides__layout">
+        <div class="about-sticky-slides__copy" data-sticky-copy>
+          {% for block in section.blocks %}
+            {% liquid
+              assign slide_video = block.settings.video_url
+              assign slide_bg = block.settings.background
+              assign has_bg = false
+              if slide_bg != blank and slide_bg.alpha > 0
+                assign has_bg = true
+              endif
+            %}
+            <article
+              class="about-sticky-slides__item"
+              data-sticky-item
+              data-block-id="{{ block.id }}"
+              {% if slide_video != blank %}
+                data-video="{{ slide_video | escape }}"
+              {% endif %}
+              {% if has_bg %}
+                data-bg="{{ slide_bg | escape }}"
+              {% endif %}
+              {{ block.shopify_attributes }}
+            >
+              {% if block.settings.eyebrow %}
+                <p class="about-sticky-slides__item-eyebrow">{{ block.settings.eyebrow | escape }}</p>
+              {% endif %}
+              {% if block.settings.heading %}
+                <h3 class="about-sticky-slides__item-heading">{{ block.settings.heading | escape }}</h3>
+              {% endif %}
+              {% if block.settings.body != blank %}
+                <div class="about-sticky-slides__item-body rte">{{ block.settings.body }}</div>
+              {% endif %}
+
+              {% if block.settings.cta_label != blank and block.settings.cta_link != blank %}
+                <a class="about-sticky-slides__item-link" href="{{ block.settings.cta_link | escape }}">{{ block.settings.cta_label | escape }}</a>
+              {% endif %}
+
+              {% if block.settings.image != blank %}
+                {{ block.settings.image | image_url: width: 1600 | image_tag:
+                  loading: 'lazy',
+                  decoding: 'async',
+                  hidden: 'hidden',
+                  class: 'about-sticky-slides__preload-image',
+                  data: {
+                    slide_image: ''
+                  },
+                  alt: block.settings.heading | escape
+                }}
+              {% endif %}
+            </article>
+          {% endfor %}
+        </div>
+        <div class="about-sticky-slides__visual" data-sticky-visual>
+          <div class="about-sticky-slides__visual-media" data-sticky-visual-target aria-hidden="true"></div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "About sticky slides",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "text",
+      "id": "subheading",
+      "label": "Eyebrow"
+    },
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading"
+    },
+    {
+      "type": "richtext",
+      "id": "body",
+      "label": "Body"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "slide",
+      "name": "Slide",
+      "settings": [
+        {
+          "type": "text",
+          "id": "eyebrow",
+          "label": "Eyebrow"
+        },
+        {
+          "type": "text",
+          "id": "heading",
+          "label": "Heading"
+        },
+        {
+          "type": "richtext",
+          "id": "body",
+          "label": "Body"
+        },
+        {
+          "type": "text",
+          "id": "cta_label",
+          "label": "Link label"
+        },
+        {
+          "type": "url",
+          "id": "cta_link",
+          "label": "Link URL"
+        },
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "Image"
+        },
+        {
+          "type": "url",
+          "id": "video_url",
+          "label": "Video URL",
+          "info": "MP4 video hosted on Shopify Files or CDN"
+        },
+        {
+          "type": "color",
+          "id": "background",
+          "label": "Visual background"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 6,
+  "presets": [
+    {
+      "name": "About sticky slides",
+      "blocks": [
+        {
+          "type": "slide"
+        },
+        {
+          "type": "slide"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- add an about sticky slides section that surfaces block metadata for visuals
- style the layout with a sticky media column, reserved aspect ratio, and active states with reduced-motion care
- introduce IntersectionObserver-driven swapping between lazy images and videos plus load the script on the about page

## Testing
- bundle exec theme-check *(fails: 403 Forbidden while fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68d982330f208328907d99db1d6c72f9