### PR TITLE
feat(about): optional in-page nav for sticky slides

### DIFF
--- a/assets/about-sticky.js
+++ b/assets/about-sticky.js
@@ -6,6 +6,8 @@ class AboutStickySlides {
     this.visualContainer = section.querySelector('[data-sticky-visual]');
     this.mediaTarget = section.querySelector('[data-sticky-visual-target]');
     this.visualSurface = this.mediaTarget ? this.mediaTarget.parentElement : null;
+    this.nav = section.querySelector('[data-sticky-nav]');
+    this.navLinks = this.nav ? Array.from(this.nav.querySelectorAll('[data-sticky-nav-link]')) : [];
     this.activeItem = null;
     this.activeMedia = null;
 
@@ -45,6 +47,11 @@ class AboutStickySlides {
       this.observer.observe(item);
     });
 
+    if (this.nav && this.navLinks.length) {
+      this.handleNavClick = this.handleNavClick.bind(this);
+      this.nav.addEventListener('click', this.handleNavClick);
+    }
+
     // Activate the first item immediately so an initial visual is rendered.
     this.activateItem(this.items[0]);
   }
@@ -62,6 +69,7 @@ class AboutStickySlides {
         target.classList.remove('is-active');
         this.activeMedia = null;
         this.activeItem = null;
+        this.updateNavState(null);
         return;
       }
 
@@ -84,6 +92,32 @@ class AboutStickySlides {
     this.activeItem = item;
     this.activeItem.classList.add('is-active');
     this.swapVisualForItem(item);
+    this.updateNavState(item.dataset.blockId);
+  }
+
+  handleNavClick(event) {
+    if (!this.navLinks.length) return;
+    const link = event.target.closest('[data-sticky-nav-link]');
+    if (!link || !this.nav.contains(link)) return;
+    const { blockId } = link.dataset;
+    if (!blockId) return;
+    event.preventDefault();
+    this.activateByBlockId(blockId, { scrollIntoView: true });
+    link.focus();
+  }
+
+  updateNavState(blockId) {
+    if (!this.navLinks.length) return;
+    this.navLinks.forEach((link) => {
+      const isActive = Boolean(blockId && link.dataset.blockId === blockId);
+      if (isActive) {
+        link.setAttribute('aria-current', 'true');
+        link.classList.add('is-active');
+      } else {
+        link.removeAttribute('aria-current');
+        link.classList.remove('is-active');
+      }
+    });
   }
 
   swapVisualForItem(item) {
@@ -213,6 +247,10 @@ class AboutStickySlides {
 
     if (this.mediaTarget) {
       this.mediaTarget.innerHTML = '';
+    }
+
+    if (this.nav && this.handleNavClick) {
+      this.nav.removeEventListener('click', this.handleNavClick);
     }
 
     if (this.motionQuery) {

--- a/assets/about.css
+++ b/assets/about.css
@@ -143,6 +143,54 @@
   gap: clamp(2.4rem, 5vw, 4.8rem);
 }
 
+.template-page-about .about-sticky-slides__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.template-page-about .about-sticky-slides__nav-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.template-page-about .about-sticky-slides__nav-item {
+  flex: none;
+}
+
+.template-page-about .about-sticky-slides__nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--color-foreground), 0.16);
+  background: transparent;
+  color: rgba(var(--color-foreground), 0.72);
+  font-size: 1.3rem;
+  line-height: 1.2;
+  text-decoration: none;
+  transition: background-color 200ms ease, color 200ms ease, border-color 200ms ease;
+}
+
+.template-page-about .about-sticky-slides__nav-link:hover,
+.template-page-about .about-sticky-slides__nav-link[aria-current="true"],
+.template-page-about .about-sticky-slides__nav-link.is-active {
+  background: rgba(var(--color-foreground), 0.08);
+  border-color: rgba(var(--color-foreground), 0.24);
+  color: rgb(var(--color-foreground));
+}
+
+.template-page-about .about-sticky-slides__nav-link:focus-visible {
+  outline: 0.3rem solid rgba(var(--color-foreground), 0.28);
+  outline-offset: 0.2rem;
+}
+
 .template-page-about .about-sticky-slides__intro {
   display: grid;
   gap: clamp(1rem, 3vw, 1.8rem);

--- a/sections/about-sticky-slides.liquid
+++ b/sections/about-sticky-slides.liquid
@@ -2,6 +2,7 @@
   assign intro_heading = section.settings.heading
   assign intro_subheading = section.settings.subheading
   assign intro_text = section.settings.body
+  assign show_nav = section.settings.show_inpage_nav
 %}
 
 <section
@@ -24,6 +25,33 @@
       </header>
     {% endif %}
 
+    {% if show_nav and section.blocks.size > 0 %}
+      <nav class="about-sticky-slides__nav" data-sticky-nav aria-label="Slide navigation">
+        <ul class="about-sticky-slides__nav-list" role="list">
+          {% for block in section.blocks %}
+            {% liquid
+              assign nav_label = block.settings.heading
+              if nav_label == blank
+                assign nav_label = block.settings.eyebrow
+              endif
+              if nav_label == blank
+                assign nav_label = 'Slide ' | append: forloop.index
+              endif
+              assign slide_anchor_id = 'sticky-slide-' | append: section.id | append: '-' | append: block.id
+            %}
+            <li class="about-sticky-slides__nav-item">
+              <a
+                class="about-sticky-slides__nav-link"
+                href="#{{ slide_anchor_id }}"
+                data-sticky-nav-link
+                data-block-id="{{ block.id }}"
+              >{{ nav_label | escape }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+    {% endif %}
+
     {% if section.blocks.size > 0 %}
       <div class="about-sticky-slides__layout">
         <div class="about-sticky-slides__copy" data-sticky-copy>
@@ -32,12 +60,14 @@
               assign slide_video = block.settings.video_url
               assign slide_bg = block.settings.background
               assign has_bg = false
+              assign slide_anchor_id = 'sticky-slide-' | append: section.id | append: '-' | append: block.id
               if slide_bg != blank and slide_bg.alpha > 0
                 assign has_bg = true
               endif
             %}
             <article
               class="about-sticky-slides__item"
+              id="{{ slide_anchor_id }}"
               data-sticky-item
               data-block-id="{{ block.id }}"
               {% if slide_video != blank %}
@@ -105,6 +135,12 @@
       "type": "richtext",
       "id": "body",
       "label": "Body"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_inpage_nav",
+      "label": "Show in-page navigation",
+      "default": false
     }
   ],
   "blocks": [


### PR DESCRIPTION
## Summary
- add a checkbox setting to enable an in-page navigation for the sticky slides section
- render anchored slide links and update the sticky script to sync the active state with aria-current
- style the navigation pills with hover and focus-visible treatments for keyboard accessibility

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9899a75248328bab1ef6eb751a806