### PR TITLE
fix(sticky): enable nv-sticky-slides on all templates (enabled_on + presets)

### DIFF
--- a/sections/nv-sticky-slides.liquid
+++ b/sections/nv-sticky-slides.liquid
@@ -86,6 +86,9 @@
   "name": "Sticky slides",
   "tag": "section",
   "class": "section",
+  "enabled_on": {
+    "templates": ["*"]
+  },
   "settings": [
     {
       "type": "range",
@@ -138,18 +141,7 @@
   ],
   "presets": [
     {
-      "name": "Sticky slides",
-      "blocks": [
-        {
-          "type": "slide"
-        },
-        {
-          "type": "slide"
-        },
-        {
-          "type": "slide"
-        }
-      ]
+      "name": "Sticky slides"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- allow the nv-sticky-slides section to be enabled on all templates using the enabled_on flag
- simplify the preset configuration to the required Sticky slides entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9cb00139883289a410564db24a63c