### PR TITLE
Fix sticky slides preload image attributes

### DIFF
--- a/assets/nv-sticky.css
+++ b/assets/nv-sticky.css
@@ -54,6 +54,10 @@
   display: none;
 }
 
+.nv-sticky-slides__preload-image {
+  display: none;
+}
+
 @media (min-width: 768px) {
   .nv-sticky-slides__layout {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);

--- a/sections/nv-sticky-slides.liquid
+++ b/sections/nv-sticky-slides.liquid
@@ -37,11 +37,10 @@
         {% if block.settings.image != blank %}
           {{ block.settings.image | image_url: width: 2400 | image_tag:
             loading: 'lazy',
-            hidden: 'hidden',
             decoding: 'async',
-            data: {
-              slide_image: ''
-            },
+            'data-slide-image': 'true',
+            class: 'nv-sticky-slides__preload-image',
+            'aria-hidden': 'true',
             alt: block.settings.title | escape
           }}
         {% endif %}


### PR DESCRIPTION
## Summary
- update sticky slides preload image_tag to use valid aria and data attributes with class
- hide new preload image class in sticky stylesheet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ccf337fc832889508ee35e97f139